### PR TITLE
feat(BUX-184): add NewPaymail function

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -389,6 +389,25 @@ describe("UnreserveUtxos", () => {
   });
 });
 
+describe('NewPaymail', () => {
+  test('http result', async () => {
+    fetchMock.mockResponse('{}');
+    await runTests([httpTestClient], async (buxClient: TransportService) => {
+      const key = 'mock_key';
+      const address = 'mock_address';
+      await buxClient.NewPaymail(key, address);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${serverURL}/paymail`,
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ key, address }),
+        })
+      );
+    });
+  })
+});
+
 describe('Finalize transaction', () => {
   test('draftTxJSON', async () => {
     const buxClient = new BuxClient(serverURL, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -561,6 +561,25 @@ class BuxClient implements TransportService {
   }
 
   /**
+   * Register a new paymail
+   * @param {string} key - The rawXPubKey
+   * @param {string} address - The full paymail address
+   * @param {string} [publicName] - The public name (optional)
+   * @param {string} [avatar] - The avatar (optional)
+   * @param {Metadata} [metadata] - The metadata to record on the destination (optional)
+   * @returns {void}
+   */
+  async NewPaymail(
+    key: string,
+    address: string,
+    publicName?: string,
+    avatar?: string,
+    metadata?: Metadata
+  ): Promise<void> {
+    return this.client.transport.NewPaymail(key, address, publicName, avatar, metadata);
+  }
+
+  /**
    * Get all details of the transaction by the given ID
    *
    * @param {string} txID Transaction ID

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -613,6 +613,7 @@ export interface TransportService {
   UpdateDestinationMetadataByID(id: string, metadata: Metadata): Promise<Destination>;
   UpdateDestinationMetadataByAddress(address: string, metadata: Metadata): Promise<Destination>;
   UpdateDestinationMetadataByLockingScript(lockingScript: string, metadata: Metadata): Promise<Destination>;
+  NewPaymail(key: string, address: string, publicName?: string, avatar?: string, metadata?: Metadata): Promise<void>;
   GetTransaction(txID: string): Promise<Transaction>;
   GetTransactions(conditions: Conditions, metadata: Metadata, queryParams: QueryParams): Promise<Transactions>;
   GetTransactionsCount(conditions: Conditions, metadata: Metadata): Promise<number>;

--- a/src/transports/graphql.ts
+++ b/src/transports/graphql.ts
@@ -824,6 +824,19 @@ class TransportGraphQL implements TransportService {
     return this.doGraphQLMutation(query, variables, 'destination_metadata');
   }
 
+  // Register a new paymail
+  async NewPaymail(
+    key: string,
+    address: string,
+    publicName?: string,
+    avatar?: string,
+    metadata?: Metadata
+  ): Promise<void> {
+    // TODO: Implement this
+    // Looks like the implementation is missing in Bux Server GraphQL
+    return Promise.resolve();
+  }
+
   async GetTransaction(txID: string): Promise<Transaction> {
     const query = gql`
       {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -468,6 +468,34 @@ class TransportHTTP implements TransportService {
   }
 
   /**
+   * Register a new paymail
+   * @param {string} key - The rawXPubKey
+   * @param {string} address - The full paymail address
+   * @param {string} [publicName] - The public name (optional)
+   * @param {string} [avatar] - The avatar (optional)
+   * @param {Metadata} [metadata] - The metadata to record on the destination (optional)
+   * @returns {void}
+   */
+  async NewPaymail(
+    key: string,
+    address: string,
+    publicName?: string,
+    avatar?: string,
+    metadata?: Metadata
+  ): Promise<void> {
+    await this.doHTTPRequest(`${this.serverUrl}/paymail`, {
+      method: "POST",
+      body: JSON.stringify({
+        key,
+        address,
+        public_name: publicName,
+        avatar,
+        metadata,
+      }),
+    });
+  }
+
+  /**
    * Get a transaction by ID
    * @param txID string Transaction ID to retrieve
    * @returns Transaction


### PR DESCRIPTION
⚠️  I have left a TODO for the GraphQL function:

![image](https://github.com/BuxOrg/js-buxclient/assets/5285430/1a2afbaf-d32d-446a-a320-b943c271889d)

...because in the go-buxclient it also isn't implemented:

![image](https://github.com/BuxOrg/js-buxclient/assets/5285430/11ad0f21-58b5-4ef3-984f-96dcaab5d8a0)

I took a look at the Bux Server GraphQL schema and it seems to be missing this feature there as well.